### PR TITLE
Improve API macro implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+cmake_minimum_required(VERSION 3.0)
+
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.0)
 
 project(pngparts)
 
+option(BUILD_SHARED_LIBS "Build shared libraries")
+
 set(pngparts_src
   api.c api.h)
 
 add_library(pngparts ${pngparts_src})
+target_compile_definitions(pngparts PRIVATE "PNGPARTS_EXPORTS")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,4 +8,8 @@ set(pngparts_src
   api.c api.h)
 
 add_library(pngparts ${pngparts_src})
-target_compile_definitions(pngparts PRIVATE "PNGPARTS_EXPORTS")
+if (BUILD_SHARED_LIBS)
+  if (WIN32)
+    target_compile_definitions(pngparts PUBLIC "PNGPARTS_API_SHARED")
+  endif(WIN32)
+endif(BUILD_SHARED_LIBS)

--- a/src/api.c
+++ b/src/api.c
@@ -11,9 +11,9 @@
 #include "api.h"
 
 int pngparts_api_info(void){
-#ifdef PNGPARTS_EXPORTS
-  return 0;
-#else
-  return -1;
-#endif /*PNGPARTS_EXPORTS*/
+  int out = 0;
+#ifdef PNGPARTS_API_SHARED
+  out |= PNGPARTS_API_EXPORTS;
+#endif /*PNGPARTS_API_SHARED*/
+  return out;
 }

--- a/src/api.c
+++ b/src/api.c
@@ -11,5 +11,9 @@
 #include "api.h"
 
 int pngparts_api_info(void){
+#ifdef PNGPARTS_EXPORTS
   return 0;
+#else
+  return -1;
+#endif /*PNGPARTS_EXPORTS*/
 }

--- a/src/api.h
+++ b/src/api.h
@@ -15,21 +15,36 @@
  * export variable
  */
 #ifndef PNGPARTS_API
-#  ifdef _WIN32
-#    ifdef PNGPARTS_EXPORTS
+#  if (defined PNGPARTS_API_SHARED)
+#    ifdef pngparts_EXPORTS
 #      define PNGPARTS_API __declspec(dllexport)
 #    else
 #      define PNGPARTS_API __declspec(dllimport)
-#    endif /*PNGPARTS_EXPORTS*/
+#    endif /*pngparts_EXPORTS*/
 #  else
 #    define PNGPARTS_API
-#  endif /*_WIN32*/
+#  endif /*PNGPARTS_API_SHARED*/
 #endif /*PNGPARTS_API*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif /*__cplusplus*/
+
+/*
+ * API information flags
+ */
+enum pngparts_api_flag {
+  /* whether the library uses explicit exporting */
+  PNGPARTS_API_EXPORTS = 1
+};
 /*
  * API information as an integer
  */
 PNGPARTS_API
 int pngparts_api_info(void);
+
+#ifdef __cplusplus
+};
+#endif /*__cplusplus*/
 
 #endif /*__PNG_PARTS_API_H__*/

--- a/src/api.h
+++ b/src/api.h
@@ -15,8 +15,16 @@
  * export variable
  */
 #ifndef PNGPARTS_API
-#define PNGPARTS_API
-#endif
+#  ifdef _WIN32
+#    ifdef PNGPARTS_EXPORTS
+#      define PNGPARTS_API __declspec(dllexport)
+#    else
+#      define PNGPARTS_API __declspec(dllimport)
+#    endif /*PNGPARTS_EXPORTS*/
+#  else
+#    define PNGPARTS_API
+#  endif /*_WIN32*/
+#endif /*PNGPARTS_API*/
 
 /*
  * API information as an integer
@@ -24,4 +32,4 @@
 PNGPARTS_API
 int pngparts_api_info(void);
 
-#endif
+#endif /*__PNG_PARTS_API_H__*/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.0)
+
+add_executable(test_api "test-api.c")
+target_link_libraries(test_api pngparts)

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -1,0 +1,18 @@
+/*
+ * PNG-parts
+ * parts of a Portable Network Graphics implementation
+ * Copyright 2018 Cody Licorish
+ *
+ * Licensed under the MIT License.
+ *
+ * test-api.c
+ * API information test program
+ */
+
+#include "../src/api.h"
+#include <stdio.h>
+
+int main(int argc, char **argv){
+  fprintf(stdout,"API info: %i\n", pngparts_api_info());
+  return 0;
+}


### PR DESCRIPTION
## Pull request

This pull request adds a default `dllexport` macro setup for use in Win32 shared libraries.

### Proposed changes

In `src/api.h`:
- Add a new recognizable macro `PNGPARTS_API_SHARED` for activating the `dllexport` macro setup
- Use the CMake `pngparts_EXPORTS` macro to switch between import and export
- Add `pngparts_api_flag` enumeration for runtime access to compile-time option selections

In `src/api.c`:
- Update the `pngparts_api_info` function to return information about whether the library was built shared or not

In `src/CMakeLists.txt`:
- Add access to `BUILD_SHARED_LIBS` option
- Activate `PNGPARTS_API_SHARED` macro only on Windows if building a shared library

Add a top level `CMakeLists.txt`:
- Facilitate compilation of library and test programs

Add a `tests/test-api` program:
- Test the output from `pngparts_api_info`

### Mentions

- @codylico

