### PR TITLE
Incidental repairs on deflate stream

### DIFF
--- a/src/deflate.c
+++ b/src/deflate.c
@@ -1390,6 +1390,7 @@ int pngparts_deflate_one
   unsigned int trouble_counter = 0;
   unsigned int const trouble_max = fl->inscription_size+341;
   int skip_back = 1;
+  unsigned int remix_count = 0;
   while (result == PNGPARTS_API_OK
   &&  skip_back)
   {
@@ -1403,6 +1404,11 @@ int pngparts_deflate_one
     skip_back = 0;
     switch (fl->state&PNGPARTS_DEFLATE_STATE){
     case 0: /* base */
+      remix_count += 1;
+      if (remix_count > 1){
+        /* don't do the same byte twice */
+        break;
+      }
       result = pngparts_deflate_churn_input(fl, ch);
       if (result == PNGPARTS_API_OK)
         break;

--- a/src/deflate.c
+++ b/src/deflate.c
@@ -169,6 +169,11 @@ static int pngparts_deflate_ready_triple(struct pngparts_flate* fl);
  */
 static int pngparts_deflate_ready_pair(struct pngparts_flate* fl);
 
+/*
+ * Clear the inscription text.
+ * - fl the deflater structure to rewrite
+ */
+static void pngparts_deflate_clear_block(struct pngparts_flate* fl);
 
 int pngparts_deflate_ready_pair(struct pngparts_flate* fl){
   unsigned int const block_length = fl->block_length;
@@ -292,6 +297,19 @@ void pngparts_deflate_record_skippable
   return;
 }
 
+void pngparts_deflate_clear_block(struct pngparts_flate* fl) {
+  fl->inscription_pos = 0;
+  fl->block_length = 0;
+  fl->inscription_commit = 0;
+  /* add stale markers */{
+    unsigned int i;
+    for (i = 0; i < fl->inscription_size; ++i){
+      fl->inscription_text[i] |= 32768;
+    }
+  }
+  return;
+}
+
 int pngparts_deflate_churn_input
   (struct pngparts_flate *fl, int ch)
 {
@@ -377,8 +395,10 @@ int pngparts_deflate_churn_input
             }
             fl->alt_inscription[0] = 3;
             fl->alt_inscription[1] = history_point;
-            pngparts_deflate_queue_pair
+            result = pngparts_deflate_queue_pair
               (fl, fl->alt_inscription[0], fl->alt_inscription[1]);
+            if (result == PNGPARTS_API_NOT_FOUND)
+                break;
           }
         } else {
           /* block is full */
@@ -561,9 +581,11 @@ int pngparts_deflate_queue_check
 int pngparts_deflate_queue_value
   (struct pngparts_flate *fl, unsigned short int value)
 {
-  if (fl->block_length < fl->inscription_size){
-    fl->inscription_text[fl->block_length] = value;
-    fl->block_length += 1;
+  unsigned int const commit = fl->inscription_commit;
+  if (commit < fl->inscription_size){
+    fl->inscription_text[commit] = value;
+    fl->block_length = commit + 1;
+    fl->inscription_commit = commit + 1;
     return PNGPARTS_API_OK;
   } else return PNGPARTS_API_OVERFLOW;
 }
@@ -640,7 +662,9 @@ int pngparts_deflate_compose_tables(struct pngparts_flate *fl){
         } else result = PNGPARTS_API_BAD_BLOCK;
         break;
       case 1:
-        code_switch = 2;
+        if (value < 32768) {
+          code_switch = 2;
+        } else result = PNGPARTS_API_BAD_BLOCK;
         break;
       case 2:
         if (value < 30){
@@ -655,7 +679,9 @@ int pngparts_deflate_compose_tables(struct pngparts_flate *fl){
         } else result = PNGPARTS_API_BAD_BLOCK;
         break;
       case 3:
-        code_switch = 0;
+        if (value < 32768) {
+          code_switch = 0;
+        } else result = PNGPARTS_API_BAD_BLOCK;
         break;
       }
       if (result != PNGPARTS_API_OK)
@@ -787,12 +813,11 @@ int pngparts_deflate_fashion_chunk
     }
     if (fl->inscription_pos >= fl->block_length){
       /* back to initial state */
-      fl->block_length = 0;
-      fl->inscription_commit = 0;
       if (last) {
         state = 5;
       } else
         state = 0;
+      pngparts_deflate_clear_block(fl);
       result = PNGPARTS_API_LOOPED_STATE;
     }
     break;
@@ -846,9 +871,7 @@ int pngparts_deflate_fashion_chunk
           } else
             state = 0;
           /* clear the block */
-          fl->inscription_pos = 0;
-          fl->block_length = 0;
-          fl->inscription_commit = 0;
+          pngparts_deflate_clear_block(fl);
         } else if (value > 256) {
           struct pngparts_flate_extra const extra =
               pngparts_flate_length_decode(value);

--- a/src/pngread.c
+++ b/src/pngread.c
@@ -684,6 +684,9 @@ int pngparts_pngread_idat_msg
             idat->nextbuf + 16 - idat->next_left, idat->next_left);
           z_result = (*idat->z.churn_cb)
             (idat->z.cb_data, PNGPARTS_API_Z_NORMAL);
+          if (z_result < 0){
+            /* the zlib stream is corrupted; give up and */break;
+          }
         } else z_result = PNGPARTS_API_OK;
         /* report bytes */ {
           unsigned int byte_count = (*idat->z.output_left_cb)(idat->z.cb_data);
@@ -709,7 +712,7 @@ int pngparts_pngread_idat_msg
               pngparts_pngread_idat_shift(idat, 1);
               memset(idat->nextbuf, 0, 8 * sizeof(unsigned char));
               if (filter_code > 4) {
-                result = PNGPARTS_API_WEIRD_FILTER;
+                z_result = PNGPARTS_API_WEIRD_FILTER;
                 break;
               }
               /*fprintf(stderr, "line %3li: filter %i\n",
@@ -790,10 +793,8 @@ int pngparts_pngread_idat_msg
             /* done */
           }break;
         }
-        if (result == PNGPARTS_API_WEIRD_FILTER){
-          /* override good z_result */
-          z_result = PNGPARTS_API_WEIRD_FILTER;
-          break;
+        if (z_result == PNGPARTS_API_WEIRD_FILTER){
+          /* the scanline stream is broken, so */break;
         }
         if (idat->x >= idat->line_width) {
           pngparts_pngread_idat_add(idat, pixel_byte_size);

--- a/src/pngwrite.c
+++ b/src/pngwrite.c
@@ -148,7 +148,7 @@ int pngparts_pngwrite_generate(struct pngparts_png* w){
        * 6  - unknown chunk CRC
        * 7  - IHDR handling
        */
-    int ch;
+    int ch = -256;
     switch (state){
     case 0: /* start */
       if (shortpos < 8){
@@ -388,7 +388,11 @@ int pngparts_pngwrite_generate(struct pngparts_png* w){
     }
     if (result != PNGPARTS_API_OK)
       break;
-    else /* put actual character */ {
+    else if (ch == -256){
+      /* character did not get set, so break */
+      result = PNGPARTS_API_BAD_STATE;
+      break;
+    } else /* put actual character */ {
       w->buf[w->pos] = (unsigned char)(ch & 255);
       w->pos += 1;
     }

--- a/tests/test-aux-pngread.c
+++ b/tests/test-aux-pngread.c
@@ -42,7 +42,7 @@ int test_image_header
     "  \"interlace\": %i\n}}\n",
     width, height, bit_depth, color_type, compression, filter, interlace
   );
-  if (width > 20000 || height > 20000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;

--- a/tests/test-aux-pngread.c
+++ b/tests/test-aux-pngread.c
@@ -42,7 +42,7 @@ int test_image_header
     "  \"interlace\": %i\n}}\n",
     width, height, bit_depth, color_type, compression, filter, interlace
   );
-  if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 20000 || height > 20000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;

--- a/tests/test-aux-pngwrite.c
+++ b/tests/test-aux-pngwrite.c
@@ -39,7 +39,7 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
-  if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 20000 || height > 20000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;

--- a/tests/test-aux-pngwrite.c
+++ b/tests/test-aux-pngwrite.c
@@ -39,7 +39,7 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
-  if (width > 20000 || height > 20000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;

--- a/tests/test-aux8-pngread.c
+++ b/tests/test-aux8-pngread.c
@@ -44,7 +44,7 @@ int test_image_header
     "  \"interlace\": %i\n}}\n",
     width, height, bit_depth, color_type, compression, filter, interlace
   );
-  if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;

--- a/tests/test-aux8-pngwrite.c
+++ b/tests/test-aux8-pngwrite.c
@@ -68,7 +68,7 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
-  if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
+  if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
   void* bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;


### PR DESCRIPTION
## Pull request

Fixes an issue with corruption of the expanded deflate stream, among other things.

### Proposed changes

- Report invalid adaptive filter values when encountered in the PNG reader
- Prevent generation of invalid `IDAT` streams by eliminating submission of
  duplicate bytes from the zlib stream writer
- Fix composition of the expanded deflate stream

### Mentions

- @codylico

