### PR TITLE
Incidental repairs on test programs and zlib stream writer

### DIFF
--- a/src/auxi.c
+++ b/src/auxi.c
@@ -321,26 +321,38 @@ void pngparts_aux_image_get_from8
 int pngparts_aux_read_png_8
   (struct pngparts_api_image* img, char const* fname)
 {
-  struct pngparts_api_image aux_img = {
-    /* callback data */img,
-    /* image start callback (read only)*/pngparts_aux_image_start8,
-    /* image color posting callback (read only)*/pngparts_aux_image_put_to8,
-    /* image describe callback (write only)*/pngparts_aux_image_describe8,
-    /* image color fetch callback (write only)*/pngparts_aux_image_get_from8
-    };
+  struct pngparts_api_image aux_img;
+  /* aux_img */{
+    /* callback data */
+    aux_img.cb_data = img;
+    /* image start callback (read only)*/
+    aux_img.start_cb = pngparts_aux_image_start8;
+    /* image color posting callback (read only)*/
+    aux_img.put_cb = pngparts_aux_image_put_to8;
+    /* image describe callback (write only)*/
+    aux_img.describe_cb = pngparts_aux_image_describe8;
+    /* image color fetch callback (write only)*/
+    aux_img.get_cb = pngparts_aux_image_get_from8;
+  }
   return pngparts_aux_read_png_16(&aux_img, fname);
 }
 
 int pngparts_aux_write_png_8
   (struct pngparts_api_image* img, char const* fname)
 {
-  struct pngparts_api_image aux_img = {
-    /* callback data */img,
-    /* image start callback (read only)*/pngparts_aux_image_start8,
-    /* image color posting callback (read only)*/pngparts_aux_image_put_to8,
-    /* image describe callback (write only)*/pngparts_aux_image_describe8,
-    /* image color fetch callback (write only)*/pngparts_aux_image_get_from8
-    };
+  struct pngparts_api_image aux_img;
+  /* aux_img */{
+    /* callback data */
+    aux_img.cb_data = img;
+    /* image start callback (read only)*/
+    aux_img.start_cb = pngparts_aux_image_start8;
+    /* image color posting callback (read only)*/
+    aux_img.put_cb = pngparts_aux_image_put_to8;
+    /* image describe callback (write only)*/
+    aux_img.describe_cb = pngparts_aux_image_describe8;
+    /* image color fetch callback (write only)*/
+    aux_img.get_cb = pngparts_aux_image_get_from8;
+  }
   return pngparts_aux_write_png_16(&aux_img, fname);
 }
 
@@ -518,29 +530,36 @@ int pngparts_aux_write_block
     unsigned int format, unsigned int bits, void const* data,
     char const* fname)
 {
+  struct pngparts_aux_block aux_img_data;
+  struct pngparts_api_image aux_img;
   if (bits != 8 && bits != 16){
     return PNGPARTS_API_BAD_PARAM;
   }
   if (height > 0x7fFFffFF || width > 0x7fFFffFF){
     return PNGPARTS_API_BAD_PARAM;
   }
-  struct pngparts_aux_block aux_img_data = {
-    /* width */width,
-    /* height */height,
-    /* stride */stride,
-    /* vstride */vstride,
-    /* format */format,
-    /* bits */bits,
-    /* data */NULL,
-    /* const_data */data
-    };
-  struct pngparts_api_image aux_img = {
-    /* callback data */&aux_img_data,
-    /* image start callback (read only)*/NULL,
-    /* image color posting callback (read only)*/NULL,
-    /* image describe callback (write only)*/pngparts_aux_block_describe,
-    /* image color fetch callback (write only)*/pngparts_aux_block_get
-    };
+  /* aux_img_data */{
+    aux_img_data.width = width;
+    aux_img_data.height = height;
+    aux_img_data.stride = stride;
+    aux_img_data.vstride = vstride;
+    aux_img_data.format = format;
+    aux_img_data.bits = bits;
+    aux_img_data.data = NULL;
+    aux_img_data.const_data = data;
+  };
+  /* aux_img */{
+    /* callback data */
+    aux_img.cb_data = &aux_img_data;
+    /* image start callback (read only)*/
+    aux_img.start_cb = NULL;
+    /* image color posting callback (read only)*/
+    aux_img.put_cb = NULL;
+    /* image describe callback (write only)*/
+    aux_img.describe_cb = pngparts_aux_block_describe;
+    /* image color fetch callback (write only)*/
+    aux_img.get_cb = pngparts_aux_block_get;
+  };
   return pngparts_aux_write_png_16(&aux_img, fname);
 }
 
@@ -550,29 +569,36 @@ int pngparts_aux_read_block
     unsigned int format, unsigned int bits, void* data,
     char const* fname)
 {
+  struct pngparts_aux_block aux_img_data;
+  struct pngparts_api_image aux_img;
   if (bits != 8 && bits != 16){
     return PNGPARTS_API_BAD_PARAM;
   }
   if (height > 0x7fFFffFF || width > 0x7fFFffFF){
     return PNGPARTS_API_BAD_PARAM;
   }
-  struct pngparts_aux_block aux_img_data = {
-    /* width */width,
-    /* height */height,
-    /* stride */stride,
-    /* vstride */vstride,
-    /* format */format,
-    /* bits */bits,
-    /* data */data,
-    /* const_data */data
+  /* aux_img_data */{
+    aux_img_data.width = width;
+    aux_img_data.height = height;
+    aux_img_data.stride = stride;
+    aux_img_data.vstride = vstride;
+    aux_img_data.format = format;
+    aux_img_data.bits = bits;
+    aux_img_data.data = data;
+    aux_img_data.const_data = data;
     };
-  struct pngparts_api_image aux_img = {
-    /* callback data */&aux_img_data,
-    /* image start callback (read only)*/pngparts_aux_block_start,
-    /* image color posting callback (read only)*/pngparts_aux_block_put,
-    /* image describe callback (write only)*/NULL,
-    /* image color fetch callback (write only)*/NULL
-    };
+  /* aux_img */{
+    /* callback data */
+    aux_img.cb_data = &aux_img_data;
+    /* image start callback (read only)*/
+    aux_img.start_cb = pngparts_aux_block_start;
+    /* image color posting callback (read only)*/
+    aux_img.put_cb = pngparts_aux_block_put;
+    /* image describe callback (write only)*/
+    aux_img.describe_cb = NULL;
+    /* image color fetch callback (write only)*/
+    aux_img.get_cb = NULL;
+  }
   return pngparts_aux_read_png_16(&aux_img, fname);
 }
 
@@ -607,13 +633,19 @@ int pngparts_aux_read_header
     struct pngparts_png parser;
     unsigned int start_bits = 0;
     struct pngparts_aux_indirect_data aux_indirect;
-    struct pngparts_api_image aux_img = {
-      /* callback data */&aux_indirect,
-      /* image start callback (read only)*/&pngparts_aux_indirect_read_header,
-      /* image color posting callback (read only)*/NULL,
-      /* image describe callback (write only)*/NULL,
-      /* image color fetch callback (write only)*/NULL
-      };
+    struct pngparts_api_image aux_img;
+    /* aux_img */{
+      /* callback data */
+      aux_img.cb_data = &aux_indirect;
+      /* image start callback (read only)*/
+      aux_img.start_cb = &pngparts_aux_indirect_read_header;
+      /* image color posting callback (read only)*/
+      aux_img.put_cb = NULL;
+      /* image describe callback (write only)*/
+      aux_img.describe_cb = NULL;
+      /* image color fetch callback (write only)*/
+      aux_img.get_cb = NULL;
+    }
     aux_indirect.set = 0;
     do {
       pngparts_pngread_init(&parser);

--- a/src/deflate.c
+++ b/src/deflate.c
@@ -20,7 +20,7 @@ enum pngparts_deflate_last_block {
 };
 
 enum pngparts_deflate_alphabet {
-  PNGPARTS_DEFLATE_MAXALPHABET = 3+286+30,
+  PNGPARTS_DEFLATE_MAXALPHABET = 3+286+30
 };
 
 /*

--- a/src/flate.c
+++ b/src/flate.c
@@ -448,16 +448,28 @@ void pngparts_flate_dynamic_codes(struct pngparts_flate_huff* hf){
 }
 
 struct pngparts_flate_extra pngparts_flate_length_decode(int literal){
+#if (__STDC_VERSION__ >= 199901L)
   struct pngparts_flate_extra const out =
     {literal,PNGPARTS_API_NOT_FOUND,PNGPARTS_API_NOT_FOUND};
+#else
+  struct pngparts_flate_extra out =
+    {0,PNGPARTS_API_NOT_FOUND,PNGPARTS_API_NOT_FOUND};
+  out.literal = literal;
+#endif /*__STDC_VERSION__*/
   if (literal >= 257 && literal <= 285){
     return pngparts_flate_length_table[literal-257];
   }
   return out;
 }
 struct pngparts_flate_extra pngparts_flate_distance_decode(int dcode){
+#if (__STDC_VERSION__ >= 199901L)
   struct pngparts_flate_extra const out =
     {dcode,PNGPARTS_API_NOT_FOUND,PNGPARTS_API_NOT_FOUND};
+#else
+  struct pngparts_flate_extra out =
+    {0,PNGPARTS_API_NOT_FOUND,PNGPARTS_API_NOT_FOUND};
+  out.literal = dcode;
+#endif /*__STDC_VERSION__*/
   if (dcode >= 0 && dcode <= 29){
     return pngparts_flate_distance_table[dcode];
   }
@@ -465,8 +477,14 @@ struct pngparts_flate_extra pngparts_flate_distance_decode(int dcode){
 }
 
 struct pngparts_flate_extra pngparts_flate_length_encode(int length){
+#if (__STDC_VERSION__ >= 199901L)
   struct pngparts_flate_extra const out =
     {PNGPARTS_API_NOT_FOUND,length,PNGPARTS_API_NOT_FOUND};
+#else
+  struct pngparts_flate_extra out =
+    {PNGPARTS_API_NOT_FOUND,0,PNGPARTS_API_NOT_FOUND};
+  out.length_value = length;
+#endif /*__STDC_VERSION__*/
   if (length >= 3 && length <= 258){
     /* sorted */{
       int start = 0;
@@ -490,8 +508,14 @@ struct pngparts_flate_extra pngparts_flate_length_encode(int length){
 struct pngparts_flate_extra pngparts_flate_distance_encode
   (unsigned int distance)
 {
+#if (__STDC_VERSION__ >= 199901L)
   struct pngparts_flate_extra const out =
     {PNGPARTS_API_NOT_FOUND,distance,PNGPARTS_API_NOT_FOUND};
+#else
+  struct pngparts_flate_extra out =
+    {PNGPARTS_API_NOT_FOUND,0,PNGPARTS_API_NOT_FOUND};
+  out.length_value = distance;
+#endif /*__STDC_VERSION__*/
   if (distance >= 1u && distance <= 32768u){
     /* sorted */{
       int start = 0;

--- a/src/png.c
+++ b/src/png.c
@@ -242,8 +242,14 @@ unsigned long int pngparts_png_crc32_tol(struct pngparts_png_crc32 chk){
 struct pngparts_png_crc32 pngparts_png_crc32_accum
   (struct pngparts_png_crc32 chk, int ch)
 {
-  struct pngparts_png_crc32 out =
+#if (__STDC_VERSION__ >= 199901L)
+  struct pngparts_png_crc32 const out =
     {(chk.accum>>8)^(pngparts_png_crc32_pre[(chk.accum^ch)&255])};
+#else
+  struct pngparts_png_crc32 out;
+  out.accum =
+    (chk.accum>>8)^(pngparts_png_crc32_pre[(chk.accum^ch)&255]);
+#endif /*__STDC_VERSION__*/
   return out;
 }
 void pngparts_png_buffer_setup
@@ -340,8 +346,8 @@ void pngparts_png_remove_chunk_cb
   link_2ptr = &p->chunk_cbs;
   while (link_ptr != NULL) {
     if (memcmp(link_ptr->cb.name, name, 4 * sizeof(unsigned char)) == 0) {
-      *link_2ptr = link_ptr->next;
       struct pngparts_png_message message;
+      *link_2ptr = link_ptr->next;
       message.byte = 0;
       memcpy(message.name, name, 4 * sizeof(unsigned char));
       message.ptr = NULL;

--- a/src/pngread.c
+++ b/src/pngread.c
@@ -405,10 +405,10 @@ void pngparts_pngread_idat_submit
   (struct pngparts_png* p, struct pngparts_pngread_idat* idat)
 {
   int const color_type = p->header.color_type;
-  struct pngparts_api_image img;
-  pngparts_png_get_image_cb(p, &img);
   static const int multiplier[9] =
     { 0, 0xffff, 0x5555, 0x2492, 0x1111, 0, 0, 0, 0x0101 };
+  struct pngparts_api_image img;
+  pngparts_png_get_image_cb(p, &img);
   switch (idat->pixel_size) {
   case 1: /* either L/1 or index/1 */
   case 2: /* either L/2 or index/2 */

--- a/src/pngwrite.c
+++ b/src/pngwrite.c
@@ -484,10 +484,10 @@ void pngparts_pngwrite_idat_fetch
   (struct pngparts_png* p, struct pngparts_pngwrite_idat* idat)
 {
   int const color_type = p->header.color_type;
-  struct pngparts_api_image img;
-  pngparts_png_get_image_cb(p, &img);
   static const int multiplier[9] =
     { 0, 0xffff, 0x5555, 0x2492, 0x1111, 0, 0, 0, 0x0101 };
+  struct pngparts_api_image img;
+  pngparts_png_get_image_cb(p, &img);
   switch (idat->pixel_size) {
   case 1: /* either L/1 or index/1 */
   case 2: /* either L/2 or index/2 */

--- a/src/zwrite.c
+++ b/src/zwrite.c
@@ -61,7 +61,6 @@ int pngparts_zwrite_generate(void *zs_v, int mode){
   struct pngparts_z *zs = (struct pngparts_z *)zs_v;
   int result = zs->last_result;
   int state = zs->state;
-  int shortpos = zs->shortpos;
   int sticky_finish = ((mode&PNGPARTS_API_Z_FINISH) != 0);
   int trouble_counter = 0;
   if (result == PNGPARTS_API_OVERFLOW){
@@ -216,7 +215,6 @@ int pngparts_zwrite_generate(void *zs_v, int mode){
   }
   zs->last_result = result;
   zs->state = (short)state;
-  zs->shortpos = (short)shortpos;
   if (result){
     zs->flags_tf |= 2;
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,45 +1,45 @@
 cmake_minimum_required(VERSION 3.0)
 
-add_executable(test_api "test-api.c")
-target_link_libraries(test_api pngparts)
+add_executable(pngparts_test_api "test-api.c")
+target_link_libraries(pngparts_test_api pngparts)
 
-add_executable(test_z "test-z.c")
-target_link_libraries(test_z pngparts)
+add_executable(pngparts_test_z "test-z.c")
+target_link_libraries(pngparts_test_z pngparts)
 
-add_executable(test_zread "test-zread.c")
-target_link_libraries(test_zread pngparts)
+add_executable(pngparts_test_zread "test-zread.c")
+target_link_libraries(pngparts_test_zread pngparts)
 
-add_executable(test_huff "test-huff.c")
-target_link_libraries(test_huff pngparts)
+add_executable(pngparts_test_huff "test-huff.c")
+target_link_libraries(pngparts_test_huff pngparts)
 
-add_executable(test_png "test-png.c")
-target_link_libraries(test_png pngparts)
+add_executable(pngparts_test_png "test-png.c")
+target_link_libraries(pngparts_test_png pngparts)
 
-add_executable(test_pngread "test-pngread.c")
-target_link_libraries(test_pngread pngparts)
+add_executable(pngparts_test_pngread "test-pngread.c")
+target_link_libraries(pngparts_test_pngread pngparts)
 
-add_executable(test_zwrite "test-zwrite.c")
-target_link_libraries(test_zwrite pngparts)
+add_executable(pngparts_test_zwrite "test-zwrite.c")
+target_link_libraries(pngparts_test_zwrite pngparts)
 
-add_executable(test_pngwrite "test-pngwrite.c")
-target_link_libraries(test_pngwrite pngparts)
+add_executable(pngparts_test_pngwrite "test-pngwrite.c")
+target_link_libraries(pngparts_test_pngwrite pngparts)
 
-add_executable(test_hash "test-hash.c")
-target_link_libraries(test_hash pngparts)
+add_executable(pngparts_test_hash "test-hash.c")
+target_link_libraries(pngparts_test_hash pngparts)
 
-add_executable(test_flate "test-flate.c")
-target_link_libraries(test_flate pngparts)
+add_executable(pngparts_test_flate "test-flate.c")
+target_link_libraries(pngparts_test_flate pngparts)
 
 if (PNGPARTS_INCLUDE_AUX)
-add_executable(test_aux_pngread "test-aux-pngread.c")
-target_link_libraries(test_aux_pngread pngparts)
+add_executable(pngparts_test_aux_pngread "test-aux-pngread.c")
+target_link_libraries(pngparts_test_aux_pngread pngparts)
 
-add_executable(test_aux_pngwrite "test-aux-pngwrite.c")
-target_link_libraries(test_aux_pngwrite pngparts)
+add_executable(pngparts_test_aux_pngwrite "test-aux-pngwrite.c")
+target_link_libraries(pngparts_test_aux_pngwrite pngparts)
 
-add_executable(test_aux8_pngread "test-aux8-pngread.c")
-target_link_libraries(test_aux8_pngread pngparts)
+add_executable(pngparts_test_aux8_pngread "test-aux8-pngread.c")
+target_link_libraries(pngparts_test_aux8_pngread pngparts)
 
-add_executable(test_aux8_pngwrite "test-aux8-pngwrite.c")
-target_link_libraries(test_aux8_pngwrite pngparts)
+add_executable(pngparts_test_aux8_pngwrite "test-aux8-pngwrite.c")
+target_link_libraries(pngparts_test_aux8_pngwrite pngparts)
 endif (PNGPARTS_INCLUDE_AUX)

--- a/tests/test-api.c
+++ b/tests/test-api.c
@@ -13,9 +13,10 @@
 #include <stdio.h>
 
 int main(int argc, char **argv){
+  int i;
   fprintf(stdout,"API info: %i\n", pngparts_api_info());
   fprintf(stdout,"Error string:\n");
-  for (int i = -27; i <= 3; ++i){
+  for (i = -27; i <= 3; ++i){
     fprintf(stdout,"  %i:\t%s\n",i,pngparts_api_strerror(i));
   }
   return 0;

--- a/tests/test-aux-pngread.c
+++ b/tests/test-aux-pngread.c
@@ -32,6 +32,7 @@ int test_image_header
     short color_type, short compression, short filter, short interlace)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   fprintf(stderr, "{\"image info\":{\n"
     "  \"width\": %li,\n"
     "  \"height\": %li,\n"
@@ -43,7 +44,7 @@ int test_image_header
     width, height, bit_depth, color_type, compression, filter, interlace
   );
   if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-aux-pngwrite.c
+++ b/tests/test-aux-pngwrite.c
@@ -39,8 +39,9 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-aux8-pngread.c
+++ b/tests/test-aux8-pngread.c
@@ -34,6 +34,7 @@ int test_image_header
     short color_type, short compression, short filter, short interlace)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   fprintf(stderr, "{\"image info\":{\n"
     "  \"width\": %li,\n"
     "  \"height\": %li,\n"
@@ -45,7 +46,7 @@ int test_image_header
     width, height, bit_depth, color_type, compression, filter, interlace
   );
   if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-aux8-pngwrite.c
+++ b/tests/test-aux8-pngwrite.c
@@ -68,8 +68,9 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   if (width > 10000 || height > 10000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-pngread.c
+++ b/tests/test-pngread.c
@@ -36,6 +36,7 @@ int test_image_header
     short color_type, short compression, short filter, short interlace)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   fprintf(stderr, "{\"image info\":{\n"
     "  \"width\": %li,\n"
     "  \"height\": %li,\n"
@@ -47,7 +48,7 @@ int test_image_header
     width, height, bit_depth, color_type, compression, filter, interlace
   );
   if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-pngwrite.c
+++ b/tests/test-pngwrite.c
@@ -70,8 +70,9 @@ int test_image_resize
   (void* img_ptr, long int width, long int height)
 {
   struct test_image *img = (struct test_image*)img_ptr;
+  void* bytes;
   if (width > 2000 || height > 2000) return PNGPARTS_API_UNSUPPORTED;
-  void* bytes = malloc(width*height * 4);
+  bytes = malloc(width*height * 4);
   if (bytes == NULL) return PNGPARTS_API_UNSUPPORTED;
   img->width = (int)width;
   img->height = (int)height;

--- a/tests/test-zread.c
+++ b/tests/test-zread.c
@@ -95,6 +95,7 @@ int main(int argc, char**argv){
       pngparts_z_setup_input(&reader,inbuf,readlen);
       pngparts_z_setup_output(&reader,outbuf,sizeof(outbuf));
       while (!pngparts_z_input_done(&reader)){
+        size_t writelen;
         result = pngparts_zread_parse(&reader,PNGPARTS_API_Z_NORMAL);
         if (result == PNGPARTS_API_NEED_DICT
         &&  dict_fname != NULL)
@@ -158,7 +159,7 @@ int main(int argc, char**argv){
           if (result != PNGPARTS_API_OK) break;
           else continue;
         } else if (result < 0) break;
-        size_t writelen = pngparts_z_output_left(&reader);
+        writelen = pngparts_z_output_left(&reader);
         if (writelen > 0){
           size_t writeresult =
             fwrite(outbuf,sizeof(unsigned char),writelen,to_write);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
 
-add_executable(tool_makecrc "tool-makecrc.c")
-#target_link_libraries(tool_makecrc pngparts)
+add_executable(pngparts_tool_makecrc "tool-makecrc.c")
+#target_link_libraries(pngparts_tool_makecrc pngparts)
 


### PR DESCRIPTION
## Pull request

Fixes issue #36.

### Proposed changes

- Remove unused variable in code causing invalid encoding of Adler32 checksums.
- Rename test programs from `test_...` to `pngparts_test_...` to avoid possible name clashes.
- Rename tool program from `tool_...` to `pngparts_tool_...` to avoid possible name clash.
- Adjust source code to comply with C89.

### Mentions

- @codylico

